### PR TITLE
ci: add PR test workflow and automated npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Run unit tests
+        run: npx ng test signal-query --no-watch

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,8 +3,17 @@ name: Publish to npm
 # Publishes @ali7040/ng-signal-query to the public npm registry whenever a
 # GitHub Release is published. Can also be triggered manually.
 #
-# Prerequisite: add a repository secret `NPM_TOKEN` (an npm *Automation* access
-# token) under Settings → Secrets and variables → Actions.
+# Authentication uses npm Trusted Publishing (OIDC) — there is no NPM_TOKEN
+# secret to manage, leak, or rotate. GitHub proves this workflow's identity to
+# npm directly.
+#
+# One-time setup on npmjs.com (package → Settings → Trusted Publisher):
+#   Publisher:         GitHub Actions
+#   Organization/user: Ali7040
+#   Repository:        ng-signal-query
+#   Workflow filename: publish-npm.yml
+#
+# Provenance is generated automatically under Trusted Publishing.
 on:
   release:
     types: [published]
@@ -12,7 +21,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # required for npm provenance
+  id-token: write # required for Trusted Publishing (OIDC) and provenance
 
 jobs:
   publish:
@@ -30,6 +39,10 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
+      # Trusted Publishing requires npm >= 11.5.1; Node 22 ships with npm 10.x.
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
@@ -40,8 +53,4 @@ jobs:
         run: npx ng test signal-query --no-watch
 
       - name: Publish to npm
-        # Provenance links the package to this exact workflow run for supply-chain
-        # trust. If it ever fails on the repository URL, drop `--provenance`.
-        run: npm publish ./dist/signal-query --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish ./dist/signal-query --access public

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,47 @@
+name: Publish to npm
+
+# Publishes @ali7040/ng-signal-query to the public npm registry whenever a
+# GitHub Release is published. Can also be triggered manually.
+#
+# Prerequisite: add a repository secret `NPM_TOKEN` (an npm *Automation* access
+# token) under Settings → Secrets and variables → Actions.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # required for npm provenance
+
+jobs:
+  publish:
+    name: Build, test & publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Run unit tests
+        run: npx ng test signal-query --no-watch
+
+      - name: Publish to npm
+        # Provenance links the package to this exact workflow run for supply-chain
+        # trust. If it ever fails on the repository URL, drop `--provenance`.
+        run: npm publish ./dist/signal-query --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,26 +5,25 @@ CI when a GitHub Release is published. You no longer publish from your machine.
 
 ## One-time setup (repo owner)
 
-Add a repository secret named **`NPM_TOKEN`**:
+Publishing uses **npm Trusted Publishing (OIDC)** — there is **no token or secret
+to create, rotate, or leak**, and nothing that expires.
 
-1. Create an npm access token at <https://www.npmjs.com/settings/~/tokens>.
-   - **Granular token:** permissions **Read and write**, scoped to
-     `@ali7040/ng-signal-query`, with **Bypass 2FA** checked and no IP restrictions.
-   - **Classic → Automation** works too and never expires.
-2. In GitHub: *Settings → Secrets and variables → Actions → New repository secret*
-   (the **Secrets** tab — never *Variables*, which are stored in plaintext).
-   Name it `NPM_TOKEN` and paste the token.
+On <https://www.npmjs.com>, open the package →
+*Settings → Trusted Publisher → GitHub Actions*, and enter:
 
-### ⚠️ Token expiry
+| Field | Value |
+|-------|-------|
+| Organization or user | `Ali7040` |
+| Repository | `ng-signal-query` |
+| Workflow filename | `publish-npm.yml` |
+| Environment | *(leave empty)* |
 
-The current token is a 90-day granular token created **1 Aug 2026**, so it expires
-around **30 Oct 2026**.
+That's it. npm will then accept publishes **only** from this repository's
+`publish-npm.yml` workflow, and provenance is attached automatically.
 
-When it expires, `Publish to npm` fails with a `401 Unauthorized`. The fix is to
-generate a new token and update the `NPM_TOKEN` secret — no code change needed.
-
-> Set a calendar reminder ~1 week before expiry. To avoid this recurring, switch to
-> a Classic **Automation** token, which does not expire.
+> **Why not an access token?** npm explicitly warns against 2FA-bypass tokens for
+> CI. A token is a long-lived secret that can leak and (for granular tokens)
+> expires — silently breaking releases. OIDC has neither problem.
 
 ## Cutting a release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing
+
+`@ali7040/ng-signal-query` is published to the **npm registry automatically** by
+CI when a GitHub Release is published. You no longer publish from your machine.
+
+## One-time setup (repo owner)
+
+Add a repository secret named **`NPM_TOKEN`**:
+
+1. Create an npm access token at <https://www.npmjs.com/settings/~/tokens>.
+   - **Granular token:** permissions **Read and write**, scoped to
+     `@ali7040/ng-signal-query`, with **Bypass 2FA** checked and no IP restrictions.
+   - **Classic → Automation** works too and never expires.
+2. In GitHub: *Settings → Secrets and variables → Actions → New repository secret*
+   (the **Secrets** tab — never *Variables*, which are stored in plaintext).
+   Name it `NPM_TOKEN` and paste the token.
+
+### ⚠️ Token expiry
+
+The current token is a 90-day granular token created **1 Aug 2026**, so it expires
+around **30 Oct 2026**.
+
+When it expires, `Publish to npm` fails with a `401 Unauthorized`. The fix is to
+generate a new token and update the `NPM_TOKEN` secret — no code change needed.
+
+> Set a calendar reminder ~1 week before expiry. To avoid this recurring, switch to
+> a Classic **Automation** token, which does not expire.
+
+## Cutting a release
+
+1. Bump the version in [`projects/signal-query/package.json`](./projects/signal-query/package.json)
+   (e.g. `0.0.2` → `0.1.0`). Follow [semver](https://semver.org/).
+2. Update [`CHANGELOG.md`](./projects/signal-query/CHANGELOG.md).
+3. Commit and merge to `main` via PR.
+4. Create a **GitHub Release** with a tag that matches the version (e.g. `v0.1.0`).
+
+Publishing the Release triggers [`.github/workflows/publish-npm.yml`](./.github/workflows/publish-npm.yml),
+which builds, tests, and runs `npm publish` with [provenance](https://docs.npmjs.com/generating-provenance-statements).
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| [`ci.yml`](./.github/workflows/ci.yml) | push / PR to `main`, `dev` | Build the library and run the test suite |
+| [`publish-npm.yml`](./.github/workflows/publish-npm.yml) | GitHub Release published (or manual) | Publish to the npm registry |
+| [`publish-github-packages.yml`](./.github/workflows/publish-github-packages.yml) | GitHub Release published (or manual) | Publish to GitHub Packages |
+
+## Manual fallback
+
+The local script still works if you ever need it:
+
+```bash
+npm run release:npm
+```

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "@angular/forms": "^21.1.0",
     "@angular/platform-browser": "^21.1.0",
     "@angular/router": "^21.1.0",
-    "dotenv": "^8.2.0",
-    "node-fetch": "^3.3.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },


### PR DESCRIPTION
Closes #9

## What & why

Publishing to the **npm registry** was fully manual (`npm run release:npm`), and there was **no CI** validating pull requests. This adds both.

## Changes

- **`.github/workflows/ci.yml`** — on every push/PR to `main`/`dev`: `npm ci` -> `npm run build:lib` -> `npx ng test signal-query --no-watch`. Cancels superseded runs on the same ref.
- **`.github/workflows/publish-npm.yml`** — on a published GitHub Release (or manual dispatch): build, test, then `npm publish` to `https://registry.npmjs.org` with **provenance** (`id-token: write`).
- **`RELEASING.md`** — documents the release flow and the one-time secret setup.
- The existing GitHub Packages workflow is left untouched.

## Required before publishing works (owner action)

Add a repository secret **`NPM_TOKEN`** (an npm **Automation** token) under *Settings -> Secrets and variables -> Actions*. Automation tokens bypass 2FA, which CI requires.

## Testing

Ran the exact CI steps locally on this branch:

- `npm ci` -> 511 packages, clean install (lockfile in sync)
- `npm run build:lib` -> success
- `npx ng test signal-query --no-watch` -> **32/32 tests pass**

## Notes

- If npm provenance ever fails on the repository URL, drop `--provenance` from `publish-npm.yml`; the publish itself is unaffected.
