### PR TITLE
fix: make query retry opt-in (safe 0.1.0 release)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ali
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/projects/signal-query/CHANGELOG.md
+++ b/projects/signal-query/CHANGELOG.md
@@ -5,9 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0]
+
+> **No breaking changes.** Upgrading from `0.0.2` requires no code changes.
+> New behavior (retry/backoff) is **opt-in**; defaults preserve existing behavior.
+
+### Fixed
+- **Race condition in queries** — a slow, older response could overwrite fresher
+  data in the cache. Fetches now carry a generation and only the latest one commits.
+- **Duplicate requests** — two components using the same query key fired two
+  network requests. Concurrent fetches for a key now share a single in-flight request.
+- **`createSignalQuery` cache divergence** — it kept a private copy of state instead
+  of sharing the cache entry, so `setQueryData()` and invalidation could be missed.
 
 ### Added
+- **Request cancellation** — fetchers receive a `QueryFunctionContext` with an
+  `AbortSignal`: `fetcher: ({ signal }) => fetch(url, { signal })`. A forced refetch
+  or a key change aborts the request it supersedes. Zero-argument fetchers still work.
+- **Retry with exponential backoff** (opt-in) — `retry` and `retryDelay` options on
+  queries and mutations. Defaults to `0` (no retries), matching previous behavior.
+  Set `retry: 3` to enable; the default delay is 1s → 2s → 4s, capped at 30s.
+- Exported `RetryValue`, `RetryDelayValue`, `QueryFunctionContext`, `defaultRetryDelay`,
+  and `AbortError`.
+- Backward-compatibility test suite pinning the pre-0.1.0 public behavior.
+
+### Added — MutationConcurrencyStrategy
 - **MutationConcurrencyStrategy** — new `concurrencyStrategy` option for `createMutation()` controlling how overlapping `mutate()` calls are handled.
   - `merge` (default): run all mutations in parallel (preserves existing behavior).
   - `concat`: queue mutations and execute one at a time, in order.

--- a/projects/signal-query/ISSUES.md
+++ b/projects/signal-query/ISSUES.md
@@ -1,0 +1,341 @@
+# ng-signal-query — Issue Backlog
+
+This file is the working backlog. Every item here should become a GitHub issue
+(1 issue = 1 branch = 1 PR, per the [ROADMAP](./ROADMAP.md)).
+
+Issues are grouped by theme and ordered by priority within each group.
+
+Legend:
+- 🔴 **P0 / Critical** — correctness bugs or blockers. Ship first.
+- 🟠 **P1 / High** — core parity users expect from a "TanStack-like" library.
+- 🟡 **P2 / Medium** — developer experience & polish.
+- 🟣 **AI** — the features that make this library *different* from TanStack Query.
+- 🔵 **Ecosystem** — growth, docs, tooling.
+
+---
+
+## ✅ Already shipped (close these on GitHub)
+
+- **#1 — MutationConcurrencyStrategy** (`merge` / `concat` / `switch` / `exhaust`).
+  Implemented in [create-mutation.ts](./src/lib/mutation/create-mutation.ts) with tests.
+  → **Action: close issue #1 as completed** and link the commit.
+
+---
+
+## 🔴 Group A — Correctness & Stability (P0)
+
+These are real defects I can point to in the current code. They should be fixed
+before any new features, because they undermine trust in the cache.
+
+> **Status: A1–A4 shipped** ✅ (branch work). Implemented a shared fetch core
+> ([fetch-query.ts](./src/lib/core/fetch-query.ts)) with a generation guard,
+> in-flight deduplication, and `AbortSignal` cancellation, plus a retry/backoff
+> helper ([retry.ts](./src/lib/core/retry.ts)) wired into queries (default 3
+> retries) and mutations (default 0). Covered by
+> [create-query.spec.ts](./src/lib/query/create-query.spec.ts). A5 remains open.
+
+### A1. `createQuery` has no race-condition guard (out-of-order responses) — ✅ Done
+**Problem:** Unlike `createMutation` (which tracks a `generation` counter),
+[create-query.ts](./src/lib/query/create-query.ts) and
+[create-signal-query.ts](./src/lib/query/create-signal-query.ts) have no guard
+against out-of-order fetch resolution. If a refetch is triggered while a previous
+fetch is still in flight, the **slower/older** response can overwrite the newer one,
+leaving stale data in the cache.
+
+**Scope:**
+- Add a per-query `generation` (or `fetchId`) counter.
+- On resolve/reject, discard the result if `gen !== currentGen`.
+- Mirror the pattern already proven in `create-mutation.ts`.
+
+**Acceptance:** Test that fires two fetches where the first resolves *after* the
+second confirms the second's data wins.
+
+---
+
+### A2. No in-flight request deduplication — ✅ Done
+**Problem:** Every `createQuery` instance calls `fetchData()` on init. Two
+components mounting the same `['users']` key fire **two network requests** even
+though the cache entry is shared. TanStack dedupes these into one in-flight promise.
+
+**Scope:**
+- Store the in-flight `Promise` on the cache entry.
+- If a fetch is already running for a key, subscribers await the same promise.
+- Clear it on settle.
+
+**Acceptance:** Mount N components with the same key → assert `fetcher` called once.
+
+---
+
+### A3. No query cancellation / `AbortSignal` — ✅ Done
+**Problem:** `fetcher: () => Promise<T>` receives no `AbortSignal`, so requests
+can't be cancelled when a component is destroyed or a key changes. This wastes
+bandwidth and can cause the A1 race.
+
+**Scope:**
+- Change fetcher signature to `(ctx: { signal: AbortSignal }) => Promise<T>`
+  (keep the old signature working via overload for backward compat).
+- Abort on `DestroyRef` teardown and on key change in `createSignalQuery`.
+- Wire the signal into the HttpClient adapter and RxJS adapter.
+
+**Acceptance:** Destroying a component mid-fetch aborts the underlying request.
+
+---
+
+### A4. Retry with exponential backoff — ✅ Done
+**Problem:** The README roadmap and DOCS imply retry support, but
+[types.ts](./src/lib/query/types.ts) has **no `retry` option** and neither query
+nor mutation retries on failure.
+
+**Scope:**
+- Add `retry?: number | boolean | (failureCount, error) => boolean`.
+- Add `retryDelay?: number | (attempt, error) => number` (default: exponential
+  backoff, capped, with jitter).
+- Apply to both queries and mutations.
+- Respect `AbortSignal` (A3) — don't retry a cancelled request.
+
+**Acceptance:** A fetcher that fails twice then succeeds resolves after 3 attempts
+with increasing delays; `retry: false` fails immediately.
+
+---
+
+### A5. Error-handling normalization
+**Problem:** Errors are typed `unknown` and flow inconsistently. There's no
+global `onError` and no typed error surface.
+
+**Scope:**
+- Normalize error propagation across query/mutation.
+- Add optional global `onError` in QueryClient default options (see B7).
+- Document recommended app-level handling.
+
+---
+
+## 🟠 Group B — Core Parity with TanStack Query (P1)
+
+The features users coming from TanStack will immediately look for and not find.
+
+### B1. `enabled` — conditional / dependent queries
+**Problem:** No way to say "don't run until X is ready". Today the query always
+fires on init. This is one of the most-used TanStack options.
+
+**Scope:** `enabled?: boolean | Signal<boolean>`. When false, stay `idle` and skip
+fetching; when it flips true, fetch. Integrates naturally with signals.
+
+---
+
+### B2. `isFetching` vs `isLoading` (background refetch state)
+**Problem:** `QueryResult` exposes `isLoading` but not `isFetching`. There's no way
+to show a subtle "revalidating" spinner while stale data is on screen — the core
+stale-while-revalidate UX.
+
+**Scope:** Add `isFetching` (any fetch in flight) separate from `isLoading`
+(first load, no data yet). Add `isStale` signal too.
+
+---
+
+### B3. `select` — data transformation / derived selectors
+**Problem:** No `select` to derive/transform cached data without extra `computed()`
+boilerplate, and without re-running on unrelated cache changes.
+
+**Scope:** `select?: (data: T) => S`; result `data` signal reflects the selected shape.
+
+---
+
+### B4. `placeholderData` / `keepPreviousData` / `initialData`
+**Problem:** No way to seed a query or keep the previous page's data visible while
+the next loads. Paginated UIs flicker to empty on every key change.
+
+**Scope:**
+- `initialData` — seed cache synchronously.
+- `placeholderData` — value or `keepPreviousData` sentinel.
+- Wire `keepPreviousData` into `createSignalQuery` key changes.
+
+---
+
+### B5. Query-level lifecycle callbacks (`onSuccess` / `onError` / `onSettled`)
+**Problem:** Mutations have callbacks; queries don't.
+
+**Scope:** Add the three callbacks to `CreateQueryOptions`, fired on each settle.
+
+---
+
+### B6. `mutateAsync` + richer mutation context (`onMutate` → context)
+**Problem:** `mutate` returns `Promise<void>` — you can't await the result value.
+Optimistic updates use `optimisticUpdate(input)` but callbacks don't receive a
+typed context object like TanStack's `onMutate` → `context`.
+
+**Scope:**
+- Add `mutateAsync(input): Promise<TOutput>`.
+- Let `onMutate` return a context passed to `onError`/`onSettled`.
+- Pass `variables` into all mutation callbacks.
+
+---
+
+### B7. QueryClient global default options
+**Problem:** Every query repeats `staleTime`, `retry`, etc. No central config.
+
+**Scope:** `provideQueryClient({ defaultOptions: { queries, mutations } })`.
+Per-query options override defaults.
+
+---
+
+### B8. Cache persistence (localStorage / IndexedDB)
+**Problem:** Cache is memory-only; a refresh loses everything. TanStack has
+`persistQueryClient`.
+
+**Scope:** Pluggable persister interface + built-in localStorage and IndexedDB
+persisters. Serialize/restore with `dehydrate`/`hydrate` (already present for SSR).
+
+---
+
+### B9. Offline support / network mode
+**Problem:** Roadmap promises offline mutation queueing; nothing exists.
+
+**Scope:**
+- `networkMode: 'online' | 'always' | 'offlineFirst'`.
+- Queue mutations while offline, flush on reconnect (reuse the `online` listener
+  already wired in `create-query.ts`).
+
+---
+
+## 🟡 Group C — Developer Experience (P2)
+
+### C1. DevTools upgrade
+Timeline view of queries/mutations, concurrency-strategy visualization, cache
+inspector with manual invalidate/refetch buttons, and a "why did this refetch?"
+explainer. Build on the existing
+[devtools component](./src/lib/devtools/signal-query-devtools.component.ts).
+
+### C2. Request deduplication config
+Expose a dedupe window (builds on A2) so identical queries within N ms coalesce.
+
+### C3. Pause / resume queries
+Manual `pause()` / `resume()` on a query handle for wizards and modals.
+
+### C4. Query dependencies / auto-refetch chains
+Declaratively refetch query B when query A's data changes (beyond `enabled`).
+
+### C5. Structural sharing
+Preserve object references across refetches when data is deep-equal, to avoid
+needless downstream recomputation.
+
+### C6. Test utilities package
+`provideTestQueryClient()`, fake timers helpers, and a mock fetcher so consumers
+can test components using the library easily.
+
+---
+
+## 🟣 Group D — AI-Native Features (the differentiator)
+
+TanStack Query is designed for REST/GraphQL request/response. It has **no
+first-class story for LLM streaming, semantic caching, or token/cost tracking.**
+This is the wedge that makes ng-signal-query worth choosing over "just use TanStack".
+Angular signals are an excellent fit for streaming token updates.
+
+### D1. `createStreamingQuery` — first-class LLM/SSE token streaming ⭐
+**Problem:** LLM responses stream token-by-token. TanStack has no native
+streaming primitive. A signal that accumulates streamed chunks is a perfect fit.
+
+**Scope:**
+- `createStreamingQuery({ key, stream: (ctx) => AsyncIterable<Chunk> | ReadableStream })`.
+- Exposes `data` (accumulated), `chunks`, `isStreaming`, `isComplete`, plus
+  `cancel()` wired to `DestroyRef`.
+- Handles SSE, `ReadableStream`, and async iterables.
+
+**Why it wins:** Nobody in the Angular ecosystem has a clean signals-native
+streaming-query primitive. This alone is a headline feature.
+
+### D2. Semantic cache for prompts ⭐
+**Problem:** Exact-key caching misses "What's the weather?" vs "how's the weather?".
+For LLM calls, near-duplicate prompts should hit cache.
+
+**Scope:**
+- Optional embedding-based key matching with a similarity threshold.
+- Pluggable embedder (bring-your-own: Anthropic/OpenAI/local).
+- Falls back to exact-key when no embedder configured.
+
+### D3. `createAiQuery` — LLM ergonomics wrapper
+**Problem:** LLM calls need rate-limit-aware retry (429/`retry-after`), token &
+cost accounting, and streaming — bundled.
+
+**Scope:**
+- Built on A4 (retry/backoff) + D1 (streaming).
+- Exposes `tokensUsed`, `estimatedCost`, `model` signals.
+- Respects `retry-after` headers automatically.
+
+### D4. Provider adapters (Anthropic / OpenAI / Vercel AI SDK)
+Thin adapters so `stream:` / `queryFn:` accept an Anthropic or OpenAI streaming
+client directly, mapping their event shapes to D1's chunk model.
+
+### D5. Predictive prefetching
+**Problem:** `prefetchQuery` is manual. Learn navigation/access patterns and
+prefetch the *likely next* query.
+
+**Scope:** Opt-in observer that records key-access sequences and pre-warms the
+cache for high-probability transitions. Fully local, privacy-preserving.
+
+### D6. AI-assisted DevTools
+Natural-language cache queries ("show me all stale user queries"), anomaly
+detection (a query refetching far more than its peers), and plain-English
+explanations of cache state. Layers onto C1.
+
+> **Positioning:** Market this as *"TanStack Query's ergonomics + Angular signals
+> + a native AI/streaming layer."* D1 and D2 are the two features to build and
+> demo first — they are genuinely novel in the Angular ecosystem.
+
+---
+
+## 🔵 Group E — Ecosystem & Growth
+
+### E1. Landing page (high priority for stars/adoption)
+Value prop, feature grid, install, API preview, live examples, and a
+**comparison table vs TanStack Query / `rxResource`** that highlights the AI layer.
+Responsive + SEO.
+
+### E2. Live playground (StackBlitz / CodeSandbox)
+The README links say "Coming Soon" — ship real embeds and link from npm.
+
+### E3. Docs site
+Move DOCS.md into a real docs site with guides: caching, mutations & concurrency,
+optimistic updates, SSR, and the AI features.
+
+### E4. Migration guide from TanStack Query
+Side-by-side API mapping to lower the switching cost.
+
+### E5. Benchmarks
+Bundle size and update-performance benchmarks vs alternatives, published in the repo.
+
+### E6. Community assets
+`good first issue` labels, CONTRIBUTING quick-start, and a public GitHub Project board.
+
+### E7. One-click starter template + "Deploy to Vercel" button
+**Goal:** Let anyone spin up a working ng-signal-query app in one click, to lower
+the barrier to trying the library. This is an **adoption asset, not a library
+feature** — deployment is handled entirely by Vercel; we just provide the template
+and button.
+
+**Scope:**
+- Create a minimal starter repo (e.g. `ng-signal-query-starter`) — a small Angular
+  app that demonstrates a query, a mutation, and the DevTools, ready to run.
+- Add a **Deploy Button** to the starter README and the main README:
+  `[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=<STARTER_REPO_URL>)`
+- Confirm Angular build settings work on Vercel's zero-config Angular preset
+  (output dir, build command). Document any `vercel.json` needed for SPA routing.
+- Optionally mirror as a StackBlitz/CodeSandbox link (ties into **E2**).
+
+**Acceptance:** Clicking the button clones the starter and produces a live,
+working ng-signal-query demo URL with no manual configuration.
+
+**Note:** No new code in the library itself — this lives in a separate starter repo
+plus a README badge. The underlying deploy mechanism already exists (Vercel Deploy
+Button); we are packaging it for our library.
+
+---
+
+## Suggested execution order
+
+1. **A1, A2, A3, A4** — fix the foundation (correctness).
+2. **B1, B2, B6** — the parity features users hit first.
+3. **D1** — ship the streaming query and demo it (the differentiator).
+4. **E1** — landing page with the comparison table.
+5. **D2, D3** — semantic cache + AI query wrapper.
+6. Everything else by priority.

--- a/projects/signal-query/README.md
+++ b/projects/signal-query/README.md
@@ -166,6 +166,37 @@ const processStep = createMutation({
 | `switch` | `switchMap` | Discard previous, keep latest |
 | `exhaust` | `exhaustMap` | Ignore new while running |
 
+### 3c. Retry & Cancellation (opt-in)
+
+Fetchers receive an `AbortSignal` so superseded requests are cancelled automatically:
+
+```typescript
+const users = createQuery({
+  key: ['users'],
+  fetcher: ({ signal }) => fetch('/api/users', { signal }).then(r => r.json()),
+});
+```
+
+Retries are **opt-in** — by default a failed request reports its error immediately:
+
+```typescript
+const users = createQuery({
+  key: ['users'],
+  fetcher: ({ signal }) => fetch('/api/users', { signal }).then(r => r.json()),
+  retry: 3,                          // default: 0 (no retries)
+  retryDelay: (attempt) => attempt * 1000, // default: 1s → 2s → 4s, max 30s
+});
+```
+
+`retry` also accepts a predicate for conditional retries:
+
+```typescript
+retry: (failureCount, error) => failureCount < 3 && !isAuthError(error),
+```
+
+Queries using the same key **share a single in-flight request**, so mounting several
+components that read `['users']` performs one fetch.
+
 ### 4. Infinite Queries
 
 ```typescript

--- a/projects/signal-query/package.json
+++ b/projects/signal-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ali7040/ng-signal-query",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ali7040/ng-signal-query.git"

--- a/projects/signal-query/package.json
+++ b/projects/signal-query/package.json
@@ -1,6 +1,28 @@
 {
   "name": "@ali7040/ng-signal-query",
   "version": "0.1.0",
+  "description": "Signal-native server state management for Angular — queries, mutations, infinite scroll, caching, and SSR hydration built on Angular signals.",
+  "keywords": [
+    "angular",
+    "signals",
+    "query",
+    "server-state",
+    "data-fetching",
+    "cache",
+    "caching",
+    "mutation",
+    "infinite-query",
+    "pagination",
+    "ssr",
+    "hydration",
+    "optimistic-updates",
+    "async",
+    "state-management",
+    "angular-signals",
+    "tanstack-query"
+  ],
+  "author": "Ali Haider (https://github.com/ali7040)",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ali7040/ng-signal-query.git"
@@ -9,6 +31,10 @@
     "url": "https://github.com/ali7040/ng-signal-query/issues"
   },
   "homepage": "https://github.com/ali7040/ng-signal-query#readme",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/ali7040"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/projects/signal-query/src/lib/query/backward-compat.spec.ts
+++ b/projects/signal-query/src/lib/query/backward-compat.spec.ts
@@ -1,0 +1,104 @@
+import { TestBed } from '@angular/core/testing';
+import { createQuery } from './create-query';
+import { createMutation } from '../mutation/create-mutation';
+import { QueryClient } from '../core/query-client';
+import { CreateQueryOptions } from './types';
+
+/**
+ * Backward-compatibility guarantees.
+ *
+ * These tests pin the public behavior that existed before the fetch-core
+ * rewrite (race guard, deduplication, cancellation, retry). Existing apps
+ * upgrading to 0.1.0 must observe no behavioral change unless they opt in.
+ *
+ * If a change here fails, it is a breaking change for published users —
+ * fix the change, don't "fix" the test.
+ */
+describe('backward compatibility', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [QueryClient] });
+  });
+
+  const run = <T>(opts: CreateQueryOptions<T>) =>
+    TestBed.runInInjectionContext(() =>
+      createQuery<T>({ refetchOnWindowFocus: false, refetchOnReconnect: false, ...opts })
+    );
+
+  it('a failing query reports its error immediately (retry is opt-in)', async () => {
+    let attempts = 0;
+    const q = run<string>({
+      key: ['compat', 'no-retry-by-default'],
+      fetcher: async () => {
+        attempts++;
+        throw new Error('fail');
+      },
+    });
+
+    await new Promise<void>((r) => setTimeout(r, 20));
+
+    // Pre-0.1.0 behavior: one attempt, error surfaces right away.
+    expect(attempts).toBe(1);
+    expect(q.status()).toBe('error');
+    expect(q.error()).toBeInstanceOf(Error);
+  });
+
+  it('accepts a zero-argument fetcher (pre-AbortSignal signature)', async () => {
+    // Existing user code written as `fetcher: () => fetch(...)` must still
+    // compile and run now that the fetcher receives a context argument.
+    const legacyFetcher = () => Promise.resolve('legacy');
+
+    const q = run<string>({ key: ['compat', 'legacy-fetcher'], fetcher: legacyFetcher });
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    expect(q.status()).toBe('success');
+    expect(q.data()).toBe('legacy');
+  });
+
+  it('exposes the original QueryResult surface', () => {
+    const q = run<string>({ key: ['compat', 'surface'], fetcher: async () => 'x' });
+
+    for (const k of ['data', 'status', 'error', 'isLoading', 'isSuccess', 'isError']) {
+      expect(typeof (q as any)[k]).toBe('function');
+    }
+    expect(typeof q.refetch).toBe('function');
+  });
+
+  it('mutations still do not retry by default', async () => {
+    let attempts = 0;
+    const m = TestBed.runInInjectionContext(() =>
+      createMutation<string, string>({
+        mutationFn: async () => {
+          attempts++;
+          throw new Error('fail');
+        },
+      })
+    );
+
+    await m.mutate('x');
+
+    expect(attempts).toBe(1);
+    expect(m.status()).toBe('error');
+  });
+
+  it('opting in to retry still works', async () => {
+    let attempts = 0;
+    const q = run<string>({
+      key: ['compat', 'opt-in-retry'],
+      retry: 2,
+      retryDelay: () => 1,
+      fetcher: async () => {
+        attempts++;
+        if (attempts < 3) throw new Error('transient');
+        return 'ok';
+      },
+    });
+
+    const start = Date.now();
+    while (q.status() !== 'success' && Date.now() - start < 2000) {
+      await new Promise<void>((r) => setTimeout(r, 2));
+    }
+
+    expect(attempts).toBe(3);
+    expect(q.data()).toBe('ok');
+  });
+});

--- a/projects/signal-query/src/lib/query/create-query.ts
+++ b/projects/signal-query/src/lib/query/create-query.ts
@@ -35,7 +35,7 @@ export function createQuery<T>(
   const refetchOnWindowFocus = options.refetchOnWindowFocus ?? true;
   const refetchOnReconnect = options.refetchOnReconnect ?? true;
   const refetchInterval = options.refetchInterval ?? 0;
-  const retry = options.retry ?? 3;
+  const retry = options.retry ?? 0;
   const retryDelay = options.retryDelay ?? defaultRetryDelay;
 
   // Resolve (or create) the shared cache entry for this key.

--- a/projects/signal-query/src/lib/query/create-signal-query.spec.ts
+++ b/projects/signal-query/src/lib/query/create-signal-query.spec.ts
@@ -1,0 +1,176 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { createSignalQuery } from './create-signal-query';
+import { createQuery } from './create-query';
+import { QueryClient } from '../core/query-client';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Flush Angular effects, then let pending microtasks/promises settle. */
+async function flush() {
+  TestBed.tick();
+  await new Promise<void>((r) => setTimeout(r, 0));
+}
+
+describe('createSignalQuery', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [QueryClient] });
+  });
+
+  it('fetches on initialization', async () => {
+    const q = TestBed.runInInjectionContext(() =>
+      createSignalQuery<string>(() => ({
+        key: ['sq', 'init'],
+        fetcher: async () => 'hello',
+      }))
+    );
+
+    await flush();
+
+    expect(q.status()).toBe('success');
+    expect(q.data()).toBe('hello');
+  });
+
+  it('re-fetches when a signal dependency changes the key', async () => {
+    const id = signal(1);
+    const seen: number[] = [];
+
+    const q = TestBed.runInInjectionContext(() =>
+      createSignalQuery<string>(() => ({
+        key: ['sq', 'user', id()],
+        fetcher: async () => {
+          seen.push(id());
+          return `user-${id()}`;
+        },
+      }))
+    );
+
+    await flush();
+    expect(q.data()).toBe('user-1');
+
+    id.set(2);
+    await flush();
+
+    expect(seen).toEqual([1, 2]);
+    expect(q.data()).toBe('user-2');
+  });
+
+  it('does not refetch when the key is unchanged', async () => {
+    const tick = signal(0);
+    let calls = 0;
+
+    TestBed.runInInjectionContext(() =>
+      createSignalQuery<string>(() => {
+        tick(); // track a signal that does not affect the key
+        return {
+          key: ['sq', 'stable'],
+          fetcher: async () => {
+            calls++;
+            return 'x';
+          },
+        };
+      })
+    );
+
+    await flush();
+    expect(calls).toBe(1);
+
+    tick.set(1);
+    await flush();
+
+    expect(calls).toBe(1);
+  });
+
+  it('shares the cache entry with createQuery for the same key', async () => {
+    const client = TestBed.inject(QueryClient);
+
+    const q = TestBed.runInInjectionContext(() =>
+      createSignalQuery<string>(() => ({
+        key: ['sq', 'shared'],
+        fetcher: async () => 'from-fetch',
+      }))
+    );
+
+    await flush();
+    expect(q.data()).toBe('from-fetch');
+
+    // A cache write must be observed by the signal query (regression test:
+    // it previously kept a private copy of state).
+    client.setQueryData<string>(['sq', 'shared'], 'from-cache');
+    await flush();
+
+    expect(q.data()).toBe('from-cache');
+  });
+
+  it('surfaces errors', async () => {
+    const q = TestBed.runInInjectionContext(() =>
+      createSignalQuery<string>(() => ({
+        key: ['sq', 'err'],
+        fetcher: async () => {
+          throw new Error('nope');
+        },
+      }))
+    );
+
+    await flush();
+
+    expect(q.status()).toBe('error');
+    expect(q.error()).toBeInstanceOf(Error);
+  });
+
+  it('a superseded key does not overwrite the newer key result', async () => {
+    const id = signal(1);
+    const defs: Record<number, ReturnType<typeof deferred<string>>> = {
+      1: deferred<string>(),
+      2: deferred<string>(),
+    };
+
+    const q = TestBed.runInInjectionContext(() =>
+      createSignalQuery<string>(() => ({
+        key: ['sq', 'race', id()],
+        fetcher: () => defs[id()].promise,
+      }))
+    );
+
+    await flush();
+
+    // Switch to key 2 while key 1 is still in flight.
+    id.set(2);
+    await flush();
+
+    defs[2].resolve('second');
+    await flush();
+    expect(q.data()).toBe('second');
+
+    // The stale key-1 response resolves late and must not be shown.
+    defs[1].resolve('first');
+    await flush();
+    expect(q.data()).toBe('second');
+  });
+
+  it('refetch() re-runs the current key', async () => {
+    let calls = 0;
+    const q = TestBed.runInInjectionContext(() =>
+      createSignalQuery<string>(() => ({
+        key: ['sq', 'refetch'],
+        fetcher: async () => `call-${++calls}`,
+      }))
+    );
+
+    await flush();
+    expect(q.data()).toBe('call-1');
+
+    await q.refetch();
+    await flush();
+
+    expect(q.data()).toBe('call-2');
+  });
+});

--- a/projects/signal-query/src/lib/query/create-signal-query.ts
+++ b/projects/signal-query/src/lib/query/create-signal-query.ts
@@ -66,7 +66,7 @@ export function createSignalQuery<T>(
   const fetchEntry = (entry: CacheEntry<T>, opts: CreateQueryOptions<T>, force = false) =>
     executeQueryFetch(entry, {
       fetcher: opts.fetcher,
-      retry: opts.retry ?? 3,
+      retry: opts.retry ?? 0,
       retryDelay: opts.retryDelay ?? defaultRetryDelay,
       force,
     });

--- a/projects/signal-query/src/lib/query/types.ts
+++ b/projects/signal-query/src/lib/query/types.ts
@@ -30,7 +30,9 @@ export interface CreateQueryOptions<T> {
 
   /**
    * Number of retry attempts on failure (or a predicate).
-   * Default: 3. Use `false` / `0` to disable.
+   *
+   * Opt-in: defaults to `0` so a failed fetch reports its error immediately,
+   * preserving pre-0.1.0 behavior. Set `retry: 3` to enable backoff retries.
    */
   retry?: RetryValue;
 


### PR DESCRIPTION
## Why

`main` currently defaults queries to `retry: 3`. Publishing that as-is would **change behavior for everyone already on `0.0.2`**: a failing request would surface its error after ~7s of backoff instead of immediately, and hit the server 4 times instead of once. Nobody opted into that.

This makes retry **opt-in** so the release is safe to publish.

## Changes

- **`retry` default `3` -> `0`** in `create-query.ts` and `create-signal-query.ts`. Failure behavior is now byte-identical to `0.0.2`. Mutations already defaulted to `0`.
- **Backward-compatibility spec** (`backward-compat.spec.ts`) pinning the pre-0.1.0 public contract: immediate error on failure, zero-argument fetchers still work, `QueryResult` surface unchanged, mutations don't retry. If a future change breaks published users, these fail.
- **0.1.0** version bump + CHANGELOG + README docs for the opt-in retry/cancellation APIs.

## Upgrade impact for existing users

| | `0.0.2` | `0.1.0` |
|---|---|---|
| Failing request | errors immediately | **errors immediately** (unchanged) |
| Requests on failure | 1 | **1** (unchanged) |
| `fetcher: () => ...` | works | **works** (unchanged) |
| Duplicate queries same key | 2 requests | 1 request (bug fix) |
| Stale response overwriting fresh data | possible | prevented (bug fix) |

Users get the bug fixes for free and **change no code**. Retry is available via `retry: 3`.

## Testing

- **37/37 tests pass** (5 new backward-compat tests)
- `npm run build:lib` succeeds
- Verified the **built output**, not just source: `dist` bundle contains `retry ?? 0` in all three sites, version `0.1.0`
- `npm pack --dry-run`: 33.7 kB, 6 files, runtime deps `{ tslib }` only
