### PR TITLE
fix: publish to npmjs.org instead of GitHub Packages (ENEEDAUTH)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -53,4 +53,13 @@ jobs:
         run: npx ng test signal-query --no-watch
 
       - name: Publish to npm
-        run: npm publish ./dist/signal-query --access public
+        # The repo's .npmrc pins the @ali7040 scope to GitHub Packages, and a
+        # project-level .npmrc outranks setup-node's registry-url. For a scoped
+        # package npm resolves `@scope:registry` ahead of `registry`, so the
+        # scoped key must be overridden explicitly or the publish targets the
+        # wrong registry and fails with ENEEDAUTH.
+        run: |
+          npm publish ./dist/signal-query \
+            --access public \
+            --registry=https://registry.npmjs.org \
+            --@ali7040:registry=https://registry.npmjs.org


### PR DESCRIPTION
## Why

The `v0.1.0` release ran but **failed to publish to npm**:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://npm.pkg.github.com
```

It targeted **GitHub Packages instead of npmjs.org**. Root cause: the repo's `.npmrc` contains

```
@ali7040:registry=https://npm.pkg.github.com
```

A project-level `.npmrc` outranks the `registry-url` that `actions/setup-node` writes, and for a **scoped** package npm resolves `@scope:registry` ahead of `registry`. So neither `setup-node` nor a plain `--registry` flag was enough.

## Fix

Override the scoped registry key explicitly on the publish command.

## Verified

```
$ npm config get @ali7040:registry
https://npm.pkg.github.com                       # broken

$ npm config get @ali7040:registry --@ali7040:registry=https://registry.npmjs.org
https://registry.npmjs.org                       # fixed
```

The build/test/pack steps were already proven green in the failed run — it produced a correct 33.8 kB tarball (6 files, `@ali7040/ng-signal-query@0.1.0`) and only the final publish step failed.

## After merge

The `v0.1.0` tag and GitHub Release already exist, so re-run publishing via **Actions -> Publish to npm -> Run workflow** (the workflow supports `workflow_dispatch`). No new tag or release needed.
