### PR TITLE
fix: enable Trusted Publishing auth (E404 on publish)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,16 +32,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # `registry-url` is deliberately omitted. It makes setup-node write an
+      # .npmrc containing `_authToken=${NODE_AUTH_TOKEN}`; with no token in the
+      # environment npm sends an empty credential and fails with E404 instead of
+      # falling back to Trusted Publishing. The registry is set explicitly on the
+      # publish command instead.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
           cache: npm
 
       # Trusted Publishing requires npm >= 11.5.1; Node 22 ships with npm 10.x.
       - name: Update npm
-        run: npm install -g npm@latest
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Progress

The registry fix (#12) worked — the run reached the right registry:

```
npm notice Publishing to https://registry.npmjs.org with tag latest and public access
```

But it then failed:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@ali7040%2fng-signal-query
```

## Diagnosis

The package **does** exist on npmjs.org (`0.0.2` is published), so this is an **auth failure**, not a missing package — npm returns 404 rather than 403 to avoid leaking package existence.

The run log contains **no OIDC / trusted-publishing entries at all**, meaning npm never attempted the token exchange. Cause: `actions/setup-node`'s `registry-url` writes an `.npmrc` containing

```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
always-auth=true
```

With `NODE_AUTH_TOKEN` removed (we deleted it when switching to OIDC), npm sends an **empty credential** and fails instead of falling back to Trusted Publishing. The `npm warn Unknown user config "always-auth"` line in the log is the fingerprint of that file.

## Fix

- Omit `registry-url` from `setup-node`, so no `_authToken` line is written and npm can perform the OIDC exchange. The registry is already pinned explicitly on the publish command.
- Print `npm --version` to confirm it meets the >= 11.5.1 requirement for Trusted Publishing.

## Also verify (npmjs.com, not this repo)

If this still 404s, the Trusted Publisher connection may be incomplete. On the package's *Settings -> Trusted Publisher*, confirm:

- **"Allow `npm publish`" is checked** under *Allowed actions* (at least one action must be selected)
- The connection was saved via **Set up connection**
- Repository `Ali7040/ng-signal-query`, workflow `publish-npm.yml`, environment **empty**
